### PR TITLE
chore(deps): update Node.js engine and disable specific package rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "engines": {
-    "node": ">=20.19.6"
+    "node": ">=24.11.1"
   },
   "scripts": {
     "dev": "turbo run dev",

--- a/renovate.json
+++ b/renovate.json
@@ -18,6 +18,12 @@
   "rangeStrategy": "bump",
   "packageRules": [
     {
+      "description": "Ignore framer-motion deprecation replacement",
+      "matchPackageNames": ["framer-motion"],
+      "matchUpdateTypes": ["replacement"],
+      "enabled": false
+    },
+    {
       "description": "Pin Next.js to version 16.x",
       "matchPackageNames": [
         "next",
@@ -174,14 +180,14 @@
       ]
     },
     {
-      "description": "Pin engines.node to >=20",
+      "description": "Disable Node.js engine version updates",
       "matchDepTypes": [
         "engines"
       ],
       "matchPackageNames": [
         "node"
       ],
-      "allowedVersions": ">=20"
+      "enabled": false
     }
   ],
   "vulnerabilityAlerts": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum required Node.js version from 20.19.6 to 24.11.1.
  * Enhanced automated dependency update configuration rules for improved management of package replacements and deprecations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->