### PR TITLE
fix: 🐛 resolve double page refresh on navigation

### DIFF
--- a/apps/web/src/app/(auth)/arena/[[...conversationId]]/page.tsx
+++ b/apps/web/src/app/(auth)/arena/[[...conversationId]]/page.tsx
@@ -243,6 +243,8 @@ export default function ArenaPage() {
         if (availableModels.length > 0) {
           resetComparisons(availableModels);
         }
+        // Force refresh models by clearing the cache timestamp
+        setModelsLastLoadedAt(null);
         setConversationLoaded(false);
         setConversationError(null);
         setVoteLoadingComplete(false);
@@ -262,6 +264,7 @@ export default function ArenaPage() {
     setIsCreatingConversation,
     availableModels,
     resetComparisons,
+    setModelsLastLoadedAt,
   ]);
 
   React.useEffect(() => {

--- a/apps/web/src/components/sidebar.tsx
+++ b/apps/web/src/components/sidebar.tsx
@@ -71,10 +71,7 @@ export function Sidebar({ user }: SidebarProps) {
 
   const newConversation = useWorkflowStore(workflowSelectors.newConversation);
   const clearNewConversation = useWorkflowStore((state) => state.clearNewConversation);
-  const resetConversation = useWorkflowStore((state) => state.resetConversation);
 
-  const availableModels = useArenaStore(arenaSelectors.availableModels);
-  const resetComparisons = useArenaStore((state) => state.resetComparisons);
   const mainContentReady = useArenaStore(arenaSelectors.mainContentReady);
 
   const currentPath = pathname;
@@ -193,13 +190,6 @@ export function Sidebar({ user }: SidebarProps) {
               <motion.div
                 whileHover={{ x: 2 }}
                 whileTap={{ scale: 0.98 }}
-                onClick={() => {
-                  if (!isNewChat) return;
-                  resetConversation();
-                  if (availableModels.length > 0) {
-                    resetComparisons(availableModels);
-                  }
-                }}
                 className={`
                   relative flex items-center gap-3 px-3 py-2 rounded-lg
                   transition-colors apple-transition


### PR DESCRIPTION
- Remove redundant reset logic from sidebar onClick handler
- Centralize conversation reset in arena page effect
- Add model cache invalidation when navigating to new chat

The sidebar now only handles navigation, while arena page manages its own state reset, following Next.js best practices.

## PR Type

- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] 🔧 CI/CD
- [ ] ⬆️ Dependencies
- [ ] 🎨 Style
- [ ] 🧪 Test
- [ ] 🗑️ Chore

## Related Issue

Closes #

## Description

resolve double page refresh on navigation

## Changes

resolve double page refresh on navigation

## Affected Packages

- [x] `apps/web`
- [ ] `packages/ai-hub`
- [ ] `packages/auth`
- [ ] `packages/database`
- [ ] `packages/env`
- [ ] `packages/i18n`
- [ ] `packages/model-depot`
- [ ] `packages/storage`
- [ ] `packages/ui`

## Testing

<!-- How were these changes tested? -->

- [ ] Unit tests
- [ ] E2E tests
- [ ] Manual testing

## Checklist

- [x] `pnpm lint:fix` passes
- [x] `pnpm check:types` passes
- [ ] `pnpm test` passes
- [x] `pnpm build` passes
- [x] Commit message follows [Conventional Commits](https://conventionalcommits.org)
- [ ] Documentation updated (if needed)

## Screenshots (Optional)

<!-- For UI changes -->
