### PR TITLE
feat: add row-level security policies for webdev tables

### DIFF
--- a/packages/database/migrations/0024_add_webdev_rls_policies.sql
+++ b/packages/database/migrations/0024_add_webdev_rls_policies.sql
@@ -1,0 +1,129 @@
+-- Enable RLS policies for webdev tables and verification
+--
+-- Architecture Overview:
+-- - App connects via DATABASE_URL using the postgres role (BYPASSES RLS)
+-- - All webdev API routes use the Drizzle `db` instance with manual user_id checks
+-- - RLS here is defense-in-depth: protects against future Supabase Client usage
+--   from anon/authenticated roles, and silences Supabase Security Advisor errors
+--
+-- Strategy:
+-- - verification: RLS enabled with NO policies (deny all to anon/authenticated;
+--   Better-Auth bypasses via postgres role)
+-- - webdev_sessions: direct ownership via user_id
+-- - webdev_responses / webdev_iterations: indirect ownership via session_id
+--
+
+-- 1. verification (Better-Auth internal table, no user-facing access)
+ALTER TABLE "verification" ENABLE ROW LEVEL SECURITY;
+
+-- 2. webdev_sessions (Direct ownership - has user_id)
+ALTER TABLE "webdev_sessions" ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "webdev_sessions_select_own"
+ON "webdev_sessions" FOR SELECT
+TO authenticated
+USING ((SELECT auth.uid()) = "user_id");
+
+CREATE POLICY "webdev_sessions_insert_own"
+ON "webdev_sessions" FOR INSERT
+TO authenticated
+WITH CHECK ((SELECT auth.uid()) = "user_id");
+
+CREATE POLICY "webdev_sessions_update_own"
+ON "webdev_sessions" FOR UPDATE
+TO authenticated
+USING ((SELECT auth.uid()) = "user_id")
+WITH CHECK ((SELECT auth.uid()) = "user_id");
+
+CREATE POLICY "webdev_sessions_delete_own"
+ON "webdev_sessions" FOR DELETE
+TO authenticated
+USING ((SELECT auth.uid()) = "user_id");
+
+-- 3. webdev_responses (Indirect ownership via webdev_sessions)
+ALTER TABLE "webdev_responses" ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "webdev_responses_select_own"
+ON "webdev_responses" FOR SELECT
+TO authenticated
+USING (
+  "session_id" IN (
+    SELECT "id" FROM "webdev_sessions" WHERE "user_id" = (SELECT auth.uid())
+  )
+);
+
+CREATE POLICY "webdev_responses_insert_own"
+ON "webdev_responses" FOR INSERT
+TO authenticated
+WITH CHECK (
+  "session_id" IN (
+    SELECT "id" FROM "webdev_sessions" WHERE "user_id" = (SELECT auth.uid())
+  )
+);
+
+CREATE POLICY "webdev_responses_update_own"
+ON "webdev_responses" FOR UPDATE
+TO authenticated
+USING (
+  "session_id" IN (
+    SELECT "id" FROM "webdev_sessions" WHERE "user_id" = (SELECT auth.uid())
+  )
+)
+WITH CHECK (
+  "session_id" IN (
+    SELECT "id" FROM "webdev_sessions" WHERE "user_id" = (SELECT auth.uid())
+  )
+);
+
+CREATE POLICY "webdev_responses_delete_own"
+ON "webdev_responses" FOR DELETE
+TO authenticated
+USING (
+  "session_id" IN (
+    SELECT "id" FROM "webdev_sessions" WHERE "user_id" = (SELECT auth.uid())
+  )
+);
+
+-- 4. webdev_iterations (Indirect ownership via webdev_sessions)
+ALTER TABLE "webdev_iterations" ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "webdev_iterations_select_own"
+ON "webdev_iterations" FOR SELECT
+TO authenticated
+USING (
+  "session_id" IN (
+    SELECT "id" FROM "webdev_sessions" WHERE "user_id" = (SELECT auth.uid())
+  )
+);
+
+CREATE POLICY "webdev_iterations_insert_own"
+ON "webdev_iterations" FOR INSERT
+TO authenticated
+WITH CHECK (
+  "session_id" IN (
+    SELECT "id" FROM "webdev_sessions" WHERE "user_id" = (SELECT auth.uid())
+  )
+);
+
+CREATE POLICY "webdev_iterations_update_own"
+ON "webdev_iterations" FOR UPDATE
+TO authenticated
+USING (
+  "session_id" IN (
+    SELECT "id" FROM "webdev_sessions" WHERE "user_id" = (SELECT auth.uid())
+  )
+)
+WITH CHECK (
+  "session_id" IN (
+    SELECT "id" FROM "webdev_sessions" WHERE "user_id" = (SELECT auth.uid())
+  )
+);
+
+CREATE POLICY "webdev_iterations_delete_own"
+ON "webdev_iterations" FOR DELETE
+TO authenticated
+USING (
+  "session_id" IN (
+    SELECT "id" FROM "webdev_sessions" WHERE "user_id" = (SELECT auth.uid())
+  )
+);

--- a/packages/database/migrations/meta/_journal.json
+++ b/packages/database/migrations/meta/_journal.json
@@ -169,6 +169,13 @@
       "when": 1772698098231,
       "tag": "0023_messy_starfox",
       "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "7",
+      "when": 1778198400000,
+      "tag": "0024_add_webdev_rls_policies",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## PR Type

- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 📝 Documentation
- [ ] 🔧 CI/CD
- [ ] ⬆️ Dependencies
- [ ] 🎨 Style
- [ ] 🧪 Test
- [ ] 🗑️ Chore

## Related Issue

Closes #

## Description

    row-level security policies for webdev tables

## Affected Packages

- [x] `apps/web`
- [ ] `packages/ai-hub`
- [ ] `packages/auth`
- [x] `packages/database`
- [ ] `packages/env`
- [ ] `packages/i18n`
- [ ] `packages/model-depot`
- [ ] `packages/storage`
- [ ] `packages/theme`
- [ ] `packages/ui`
- [ ] `packages/video-runtime`

## Testing

<!-- How were these changes tested? -->

- [x] Unit tests
- [x] E2E tests
- [x] Manual testing

## Checklist

- [x] `pnpm lint:fix` passes
- [x] `pnpm check:types` passes
- [x] `pnpm test` passes
- [x] `pnpm build` passes
- [ ] Commit message follows [Conventional Commits](https://conventionalcommits.org)
- [ ] Documentation updated (if needed)

## Screenshots (Optional)

<!-- For UI changes -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented data access controls to ensure users can only access and modify their own records across webdev-related features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->